### PR TITLE
Added more Safari CORS bypasses

### DIFF
--- a/src/domain_allow_list_bypass.json
+++ b/src/domain_allow_list_bypass.json
@@ -163,6 +163,48 @@
             "id": "3c4907f111e3f29488a1664d647b4e627c7d20fd"
         },
         {
+            "payload": "<allowed>.{.<attacker>",
+            "description": "Safari allows { as subdomain http://<allowed>.{.<attacker>/",
+            "filters": [],
+            "tags": ["URL", "HOST", "CORS"],
+            "id": "8e46533db2e6e27f630a1ce5716eb835ecff1159"
+        },
+        {
+            "payload": "<allowed>.}.<attacker>",
+            "description": "Safari allows } as subdomain http://<allowed>.}.<attacker>/",
+            "filters": [],
+            "tags": ["URL", "HOST", "CORS"],
+            "id": "d0796bf59bf4fbccad4bbd07e87d722b5cba0b11"
+        },
+        {
+            "payload": "<allowed>.`.<attacker>",
+            "description": "Safari allows ` as subdomain http://<allowed>.`.<attacker>/",
+            "filters": [],
+            "tags": ["URL", "HOST", "CORS"],
+            "id": "d2e1de8bc41c3353f79681994c291b53899445c4"
+        },
+        {
+            "payload": "<allowed>.£.<attacker>",
+            "description": "Safari allows £ as subdomain http://<allowed>.£.<attacker>/",
+            "filters": [],
+            "tags": ["URL", "HOST", "CORS"],
+            "id": "a286979889c2a64c7e1e9cc1f8e77637e1b5f27d"
+        },
+        {
+            "payload": "<allowed>.€.<attacker>",
+            "description": "Safari allows € as subdomain http://<allowed>.€.<attacker>/",
+            "filters": [],
+            "tags": ["URL", "HOST", "CORS"],
+            "id": "f860dbe6b1aaae1dd80031e559353c2be9c581dd"
+        },
+        {
+            "payload": "<allowed>.¥.<attacker>",
+            "description": "Safari allows ¥ as subdomain http://<allowed>.¥.<attacker>/",
+            "filters": [],
+            "tags": ["URL", "HOST", "CORS"],
+            "id": "b0a8a8fb71b77e6c462a588e6686cdf723633391"
+        },
+        {
             "payload": "<allowed>.$.<attacker>",
             "description": "Firefox and Safari allows $ as subdomain <allowed>.$.<attacker>",
             "filters": [],


### PR DESCRIPTION
Hello,

After a bit more testing, I found that these special chars are also valid in the Safari URL bar. 

Most of these were mentioned here -> https://corben.io/blog/18-6-16-advanced-cors-techniques so I suspect this has already been tested for? I was using safari on my mobile so that may have influenced the result? 

In any case, thought I'd submit a pull request just in case they had been missed. 

P.S I hope I did the hashing correct. I had to use `echo -n 'undefined<allowed>.¥.<attacker>undefined' | sha1sum`